### PR TITLE
API Sends Oldest Olympian

### DIFF
--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -2,6 +2,8 @@ class Api::V1::OlympiansController < ApplicationController
   def index
     if request.query_parameters['age'] == "youngest"
       render json: OlympianSerializer.new(Olympian.youngest).json_response
+    elsif request.query_parameters['age'] == "oldest"
+      render json: OlympianSerializer.new(Olympian.oldest).json_response
     else
       render json: OlympianSerializer.new(Olympian.all).json_response
     end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -10,4 +10,9 @@ class Olympian < ApplicationRecord
     minimum_age = Olympian.minimum(:age)
     Olympian.where(age: minimum_age)
   end
+
+  def self.oldest
+    maximum_age = Olympian.maximum(:age)
+    Olympian.where(age: maximum_age)
+  end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -38,5 +38,13 @@ RSpec.describe Olympian, type: :model do
 
       expect(Olympian.youngest[0]).to eq(@olymp_3)
     end
+
+    it "can find the oldest olympian" do
+      @olymp_1 = Olympian.create(name: "Ryan H", sex: "M", age: 25, height: 175, weight: 100, team: "USA", sport: "Typing")
+      @olymp_2 = Olympian.create(name: "Bob G", sex: "M", age: 38, height: 185, weight: 90, team: "USA", sport: "Running")
+      @olymp_3 = Olympian.create(name: "Jack Smith", sex: "M", age: 17, height: 165, weight: 95, team: "Zimbabwe", sport: "Running")
+
+      expect(Olympian.oldest[0]).to eq(@olymp_2)
+    end
   end
 end

--- a/spec/requests/api/v1/olympians_request_spec.rb
+++ b/spec/requests/api/v1/olympians_request_spec.rb
@@ -45,4 +45,19 @@ describe 'Olympians API' do
     expect(data["olympians"][0]["sport"]).to eq(@olymp_1.sport)
     expect(data["olympians"][0]["total_medals_won"]).to eq(1)
   end
+
+  it 'sends the oldest olympian' do
+    get '/api/v1/olympians?age=oldest'
+
+    expect(response).to be_successful
+
+    data = JSON.parse(response.body)
+
+    expect(data["olympians"].count).to eq(1)
+
+    expect(data["olympians"][0]["name"]).to eq(@olymp_2.name)
+    expect(data["olympians"][0]["team"]).to eq(@olymp_2.team)
+    expect(data["olympians"][0]["sport"]).to eq(@olymp_2.sport)
+    expect(data["olympians"][0]["total_medals_won"]).to eq(2)
+  end
 end


### PR DESCRIPTION
- Add option of oldest to age query parameter for `/olympians`
- Returns information for the oldest olympian

Closes #6 