### PR TITLE
API Sends Aggregrate Olympian Stats

### DIFF
--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::OlympianStatsController < ApplicationController
+  def index
+    render json: OlympianStatsSerializer.new(Olympian.all).json_response
+  end
+end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -26,4 +26,8 @@ class Olympian < ApplicationRecord
       "female_olympians": female_weight,
     }
   end
+
+  def self.average_age
+    Olympian.average(:age).round(1)
+  end
 end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -15,4 +15,15 @@ class Olympian < ApplicationRecord
     maximum_age = Olympian.maximum(:age)
     Olympian.where(age: maximum_age)
   end
+
+  def self.average_weight
+    male_weight = Olympian.where(sex: "M").average(:weight).round(1)
+    female_weight = Olympian.where(sex: "F").average(:weight).round(1)
+
+    {
+      "unit": "kg",
+      "male_olympians": male_weight,
+      "female_olympians": female_weight,
+    }
+  end
 end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -17,8 +17,8 @@ class Olympian < ApplicationRecord
   end
 
   def self.average_weight
-    male_weight = Olympian.where(sex: "M").average(:weight).round(1)
-    female_weight = Olympian.where(sex: "F").average(:weight).round(1)
+    male_weight = Olympian.where(sex: "M").average(:weight).round(1).to_f
+    female_weight = Olympian.where(sex: "F").average(:weight).round(1).to_f
 
     {
       "unit": "kg",
@@ -28,6 +28,6 @@ class Olympian < ApplicationRecord
   end
 
   def self.average_age
-    Olympian.average(:age).round(1)
+    Olympian.average(:age).round(1).to_f
   end
 end

--- a/app/serializers/olympian_stats_serializer.rb
+++ b/app/serializers/olympian_stats_serializer.rb
@@ -1,0 +1,19 @@
+class OlympianStatsSerializer
+  def initialize(olympian_data)
+    @olympian_data = olympian_data
+  end
+
+  def json_response
+    {
+      "olympian_stats": {
+        "total_competing_olympians": olympian_data.length,
+        "average_weight": olympian_data.average_weight,
+        "average_age": olympian_data.average_age
+      }
+    }
+  end
+
+  private
+
+  attr_reader :olympian_data
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/olympians', to: 'olympians#index'
+
+      get '/olympian_stats', to: 'olympian_stats#index'
     end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -46,5 +46,17 @@ RSpec.describe Olympian, type: :model do
 
       expect(Olympian.oldest[0]).to eq(@olymp_2)
     end
+
+    it "can calculate average weight" do
+      @olymp_1 = Olympian.create(name: "Ryan H", sex: "M", age: 25, height: 175, weight: 100, team: "USA", sport: "Typing")
+      @olymp_2 = Olympian.create(name: "Bob G", sex: "M", age: 38, height: 185, weight: 90, team: "USA", sport: "Running")
+      @olymp_3 = Olympian.create(name: "Jane Smith", sex: "F", age: 28, height: 165, weight: 70, team: "England", sport: "Running")
+      @olymp_4 = Olympian.create(name: "Carol G", sex: "F", age: 38, height: 160, weight: 75, team: "France", sport: "Typing")
+      @olymp_5 = Olympian.create(name: "Gary J", sex: "M", age: 45, height: 188, weight: 88, team: "Germany", sport: "Running")
+
+      expect(Olympian.average_weight[:unit]).to eq("kg")
+      expect(Olympian.average_weight[:male_olympians]).to eq(92.7)
+      expect(Olympian.average_weight[:female_olympians]).to eq(72.5)
+    end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -58,5 +58,15 @@ RSpec.describe Olympian, type: :model do
       expect(Olympian.average_weight[:male_olympians]).to eq(92.7)
       expect(Olympian.average_weight[:female_olympians]).to eq(72.5)
     end
+
+    it "can calculate average age" do
+      @olymp_1 = Olympian.create(name: "Ryan H", sex: "M", age: 25, height: 175, weight: 100, team: "USA", sport: "Typing")
+      @olymp_2 = Olympian.create(name: "Bob G", sex: "M", age: 38, height: 185, weight: 90, team: "USA", sport: "Running")
+      @olymp_3 = Olympian.create(name: "Jane Smith", sex: "F", age: 28, height: 165, weight: 70, team: "England", sport: "Running")
+      @olymp_4 = Olympian.create(name: "Carol G", sex: "F", age: 38, height: 160, weight: 75, team: "France", sport: "Typing")
+      @olymp_5 = Olympian.create(name: "Gary J", sex: "M", age: 45, height: 188, weight: 88, team: "Germany", sport: "Running")
+
+      expect(Olympian.average_age).to eq(34.8)
+    end
   end
 end

--- a/spec/requests/api/v1/olympian_stats_request_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_request_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'Olympian stats API' do
+  before(:each) do
+    @olymp_1 = Olympian.create(name: "Ryan H", sex: "M", age: 25, height: 175, weight: 100, team: "USA", sport: "Typing")
+    @olymp_2 = Olympian.create(name: "Bob G", sex: "M", age: 38, height: 185, weight: 90, team: "USA", sport: "Running")
+    @olymp_3 = Olympian.create(name: "Jane Smith", sex: "F", age: 28, height: 165, weight: 70, team: "England", sport: "Running")
+    @olymp_4 = Olympian.create(name: "Carol G", sex: "F", age: 38, height: 160, weight: 75, team: "France", sport: "Typing")
+    @olymp_5 = Olympian.create(name: "Gary J", sex: "M", age: 45, height: 188, weight: 88, team: "Germany", sport: "Running")
+  end
+
+  it "sends a breakdown of stats of all competitors" do
+    get '/api/v1/olympian_stats'
+
+    expect(response).to be_successful
+
+    data = JSON.parse(response.body)
+
+    expect(data["olympian_stats"]["total_competing_olympians"]).to eq(5)
+    expect(data["olympian_stats"]["average_weight"]["male_olympians"]).to eq(92.7)
+    expect(data["olympian_stats"]["average_weight"]["female_olympians"]).to eq(72.5)
+    expect(data["olympian_stats"]["average_age"]).to eq(34.8)
+  end
+end


### PR DESCRIPTION
- Add endpoint at GET `/api/v1/olympian_stats` to display aggregate stats about all competing olympians

Closes #8 