### PR TITLE
Add error message for requesting missing events

### DIFF
--- a/app/controllers/api/v1/events/medalists_controller.rb
+++ b/app/controllers/api/v1/events/medalists_controller.rb
@@ -1,6 +1,13 @@
 class Api::V1::Events::MedalistsController < ApplicationController
   def index
-    event = Event.find(params[:id])
-    render json: MedalistSerializer.new(event).json_response
+    if !Event.where(id: params[:id]).empty?
+      event = Event.find(params[:id])
+      render json: MedalistSerializer.new(event).json_response
+    else
+      render json: {
+        "error": "Unable to find medalists.",
+        "detail": "Could not find an event with id = #{params[:id]}. Please check your event id and try again."
+      }, status: 404
+    end
   end
 end

--- a/spec/requests/api/v1/events_request_spec.rb
+++ b/spec/requests/api/v1/events_request_spec.rb
@@ -69,4 +69,17 @@ describe 'Events API' do
     expect(data["medalists"][0]["age"]).to eq(@olymp_4.age)
     expect(data["medalists"][0]["medal"]).to eq("Gold")
   end
+
+  it "sends an error if a requested event does not exist" do
+    get "/api/v1/events/0/medalists"
+
+    expect(response).to_not be_successful
+    
+    expect(response.status).to eq(404)
+
+    data = JSON.parse(response.body)
+
+    expect(data["error"]).to eq("Unable to find medalists.")
+    expect(data["detail"]).to eq("Could not find an event with id = 0. Please check your event id and try again.")
+  end
 end


### PR DESCRIPTION
- Added an error message on `/api/v1/events/:id/medalists` when users request an event id that does not exist